### PR TITLE
Added NSCameraUsageDescription

### DIFF
--- a/apps/CameraTest/CameraTest/Info.plist
+++ b/apps/CameraTest/CameraTest/Info.plist
@@ -43,5 +43,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>NSCameraUsageDescription</key>
+	<string>Affectiva emotion recognition requires the camera. </string>	
 </dict>
 </plist>


### PR DESCRIPTION
Added `NSCameraUsageDescription` key to plist as required by iOS 10. 
See https://developer.apple.com/library/content/qa/qa1937/_index.html